### PR TITLE
Enhance Spree Admin with Price Lists and Price list Items management

### DIFF
--- a/api/lib/spree/api_configuration.rb
+++ b/api/lib/spree/api_configuration.rb
@@ -7,7 +7,7 @@ module Spree
     preference :product_attributes, :array, default: [
       :id, :name, :description, :available_on,
       :slug, :meta_description, :meta_keywords, :shipping_category_id,
-      :taxon_ids, :total_on_hand, :meta_title, :primary_taxon_id
+      :taxon_ids, :total_on_hand, :meta_title, :primary_taxon_id, :brand_taxon_id
     ]
 
     preference :product_property_attributes, :array, default: [:id, :product_id, :property_id, :value, :property_name]

--- a/api/spec/requests/spree/api/products_spec.rb
+++ b/api/spec/requests/spree/api/products_spec.rb
@@ -323,6 +323,13 @@ module Spree::Api
           expect(json_response["primary_taxon_id"]).to eq(taxon_1.id)
         end
 
+        it "puts brand taxon for the product" do
+          product_data[:brand_taxon_id] = taxon_1.id.to_s
+          post spree.api_products_path, params: { product: product_data }
+
+          expect(json_response["brand_taxon_id"]).to eq(taxon_1.id)
+        end
+
         # Regression test for https://github.com/spree/spree/issues/4123
         it "puts the created product in the given taxons" do
           product_data[:taxon_ids] = [taxon_1.id, taxon_2.id].join(',')
@@ -416,6 +423,13 @@ module Spree::Api
           put spree.api_product_path(product), params: { product: { primary_taxon_id: taxon_1.id } }
 
           expect(json_response["primary_taxon_id"]).to eq(taxon_1.id)
+        end
+
+        it "puts brand taxon for the updated product" do
+          product.brand_taxon_id = taxon_2.id
+          put spree.api_product_path(product), params: { product: { brand_taxon_id: taxon_1.id } }
+
+          expect(json_response["brand_taxon_id"]).to eq(taxon_1.id)
         end
 
         # Regression test for https://github.com/spree/spree/issues/4123

--- a/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
@@ -84,4 +84,8 @@ Spree.ready(function () {
   $('#product_primary_taxon_id').taxonAutocomplete({
     multiple: false,
   });
+
+  $('#product_brand_taxon_id').taxonAutocomplete({
+    multiple: false,
+  });
 });

--- a/backend/app/controllers/spree/admin/price_list_items_controller.rb
+++ b/backend/app/controllers/spree/admin/price_list_items_controller.rb
@@ -1,0 +1,27 @@
+module Spree
+  module Admin
+    class PriceListItemsController < ResourceController
+      belongs_to 'spree/price_list', find_by: :id
+      before_action :set_price_list
+
+      def new
+        @price_list_item = @price_list.price_list_items.build
+        @price_list_item.build_price
+      end
+
+      private
+
+      def set_price_list
+        @price_list = Spree::PriceList.find(params[:price_list_id])
+      end
+
+      def location_after_save
+        edit_admin_price_list_path(@price_list)
+      end
+
+      def price_list_item_params
+        params.require(:price_list_item).permit(:price_list_id, price_attributes: [:amount, :currency, :variant_id])
+      end
+    end
+  end
+end

--- a/backend/app/controllers/spree/admin/price_lists_controller.rb
+++ b/backend/app/controllers/spree/admin/price_lists_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Spree
+  module Admin
+    class PriceListsController < ResourceController
+      private
+
+      def location_after_save
+        edit_admin_price_list_path(@price_list)
+      end
+    end
+  end
+end

--- a/backend/app/views/spree/admin/price_list_items/_form.html.erb
+++ b/backend/app/views/spree/admin/price_list_items/_form.html.erb
@@ -1,0 +1,25 @@
+<div data-hook="admin_price_list_item_price_fields">
+  <div data-hook="admin_price_list_item_price_form">
+    <div data-hook="admin_price_list_item_price_form_variant" class="col-12">
+      <%= f.label :variant %>
+      <%= f.collection_select :variant_id, Spree::Variant.all, :id, :descriptive_name,
+                          { include_blank: true },
+                          { class: "select2 fullwidth", disabled: !f.object.new_record? } %>
+    </div>
+
+    <div data-hook="admin_price_list_item_price_form_country" class="col-12">
+      <%= f.label :country %>
+      <%= f.field_hint :country %>
+      <%= f.collection_select :country_iso, available_countries(restrict_to_zone: nil), :iso, :name,
+                          { include_blank: t(:any_country, scope: [:spree, :admin, :prices]), selected: @price_list.try(:country).try(:iso) || nil },
+                          { class: 'custom-select fullwidth', disabled: true } %>
+       <%= f.hidden_field :country_iso, value: @price_list.try(:country).try(:iso) || nil %>
+    </div>
+
+    <div data-hook="admin_price_list_item_price_form_amount" class="col-4">
+      <%= f.label :price %>
+      <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :price, currency_attr: :currency, currency: @price_list.currency %>
+    </div>
+  </div>
+</div>
+<div class="clear"></div>

--- a/backend/app/views/spree/admin/price_list_items/edit.html.erb
+++ b/backend/app/views/spree/admin/price_list_items/edit.html.erb
@@ -1,0 +1,22 @@
+<% admin_breadcrumb(link_to plural_resource_name(Spree::Product), spree.admin_products_path) %>
+<% admin_breadcrumb(link_to(plural_resource_name(Spree::PriceList), spree.admin_price_lists_path)) %>
+<% admin_breadcrumb(link_to(@price_list.name, edit_admin_price_list_path(@price_list))) %>
+
+<% admin_breadcrumb(link_to (plural_resource_name(Spree::Price)), edit_admin_price_list_path(@price_list)) %>
+<% admin_breadcrumb(t('spree.actions.edit')) %>
+
+
+<%= form_for [:admin, @price_list, @price_list_item] do |f| %>
+  <fieldset data-hook="admin_price_list_price_edit_form">
+    <legend> <%= t('.edit_price') %> </legend>
+
+    <%= f.fields_for :price do |price_form| %>
+      <%= render 'form', f: price_form %>
+    <% end %>
+    <div class="form-buttons filter-actions actions" data-hook="buttons">
+      <%= submit_tag t('spree.actions.update'), class: 'btn btn-primary' %>
+      <%= link_to t('spree.actions.cancel'), edit_admin_price_list_path(@price_list), class: 'button' %>
+    </div>
+
+  </fieldset>
+<% end %>

--- a/backend/app/views/spree/admin/price_list_items/new.html.erb
+++ b/backend/app/views/spree/admin/price_list_items/new.html.erb
@@ -1,0 +1,21 @@
+<% admin_breadcrumb(link_to plural_resource_name(Spree::Product), spree.admin_products_path) %>
+<% admin_breadcrumb(link_to(plural_resource_name(Spree::PriceList), spree.admin_price_lists_path)) %>
+<% admin_breadcrumb(link_to(@price_list.name, edit_admin_price_list_path(@price_list))) %>
+
+<% admin_breadcrumb(link_to (plural_resource_name(Spree::Price)), edit_admin_price_list_path(@price_list)) %>
+<% admin_breadcrumb(t('spree.actions.new')) %>
+
+<%= form_for [:admin, @price_list, @price_list_item] do |f| %>
+  <fieldset data-hook="admin_price_list_price_new_form">
+    <legend><%= t('.new_price') %></legend>
+
+    <%= f.fields_for :price do |price_form| %>
+      <%= render 'form', f: price_form %>
+    <% end %>
+    <div class="form-buttons filter-actions actions" data-hook="buttons">
+      <%= submit_tag t('spree.actions.create'), class: 'btn btn-primary' %>
+      <%= link_to t('spree.actions.cancel'), edit_admin_price_list_path(@price_list), class: 'button' %>
+    </div>
+
+  </fieldset>
+<% end %>

--- a/backend/app/views/spree/admin/price_lists/_form.html.erb
+++ b/backend/app/views/spree/admin/price_lists/_form.html.erb
@@ -1,0 +1,43 @@
+<div data-hook="admin_price_list_form_fields" class="row">
+  <div data-hook="admin_price_list_form_name_field" class="col-5">
+    <%= f.field_container :name do %>
+      <%= f.label :name, class: 'required' %>
+      <%= f.text_field :name, class: 'fullwidth' %>
+      <%= error_message_on :price_list, :name %>
+    <% end %>
+  </div>
+
+  <div data-hook="admin_price_list_form_country" class="col-5">
+    <%= f.field_container :country do %>
+      <%= f.label :country %>
+      <%= f.field_hint :country %>
+      <%= f.collection_select :country_iso, available_countries(restrict_to_zone: nil), :iso, :name,
+                                  {
+                                    include_blank: t(:any_country, scope: [:spree, :admin, :prices])
+                                  },
+                                  { class: 'custom-select fullwidth', disabled: !f.object.new_record? } %>
+    <% end %>
+  </div>
+
+  <div data-hook="admin_price_list_form_currency" class="col-5">
+    <%= f.field_container :currency do %>
+      <%= f.label :currency %>
+      <%= f.field_hint :currency %>
+      <%= f.select :currency,
+        Spree::Config.available_currencies.map(&:iso_code),
+        { include_blank: true },
+        { class: 'custom-select fullwidth' } %>
+      <%= error_message_on :price_list, :currency %>
+    <% end %>
+  </div>
+
+  <div data-hook="admin_price_list_form_contain_taxes" class="col-5">
+    <%= f.field_container :contain_taxes, class: %w(checkbox) do %>
+      <label>
+        <%= f.check_box(:contain_taxes) %>
+        <%= t('spree.contain_taxes') %>
+      </label>
+      <%= error_message_on :price_list, :contain_taxes %>
+    <% end %>
+  </div>
+</div>

--- a/backend/app/views/spree/admin/price_lists/_price_list_info.html.erb
+++ b/backend/app/views/spree/admin/price_lists/_price_list_info.html.erb
@@ -1,0 +1,35 @@
+<% if price_list.prices.any? %>
+  <fieldset class="no-border-bottom" data-hook="variant_prices_table">
+    <legend align="center"><%= t(".price_details") %></legend>
+    <table class="index prices">
+      <thead data-hook="prices_header">
+        <tr>
+          <th><%= Spree::Variant.model_name.human %> </th>
+          <th><%= Spree::Price.human_attribute_name(:country) %></th>
+          <th><%= Spree::Price.human_attribute_name(:currency) %></th>
+          <th><%= Spree::Price.human_attribute_name(:amount) %></th>
+          <th class="actions"></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% price_list.price_list_items.each do |price_item| %>
+          <tr id="<%= spree_dom_id price_item %>" data-hook="prices_row" class="<%= "deleted" if price_item.price.discarded? %>">
+            <td><%= price_item.price.variant.descriptive_name %></td>
+            <td><%= price_item.price.display_country %></td>
+            <td><%= price_item.price.currency %></td>
+            <td><%= price_item.price.money.to_html %></td>
+            <td class="actions">
+              <% if can?(:edit, price_item) %>
+                <%= link_to_edit_url(edit_admin_price_list_price_list_item_path(price_list, price_item), no_text: true) unless price_item.price.discarded? %>
+              <% end %>
+              <% if can?(:destroy, price_item) %>
+                &nbsp;
+                <%= link_to_delete(price_item, url: admin_price_list_price_list_item_path(price_list, price_item), no_text: true) unless price_item.price.discarded? %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </fieldset>
+<%end%>

--- a/backend/app/views/spree/admin/price_lists/edit.html.erb
+++ b/backend/app/views/spree/admin/price_lists/edit.html.erb
@@ -1,0 +1,29 @@
+<% admin_breadcrumb(link_to plural_resource_name(Spree::Product), spree.admin_products_path) %>
+<% admin_breadcrumb(link_to plural_resource_name(Spree::PriceList), spree.admin_price_lists_path) %>
+<% admin_breadcrumb(@price_list.name) %>
+
+<% content_for :page_actions do %>
+  <li id="new_price_link">
+    <%= link_to t(".new_price"), new_admin_price_list_price_list_item_path(price_list_id: @price_list.id), class: 'btn btn-primary' %>
+  </li>
+<% end if can?(:create, Spree::PriceList) %>
+
+<div data-hook="admin_price_list_edit_form_header">
+  <%= render partial: 'spree/shared/error_messages', locals: { target: @price_list } %>
+</div>
+
+<div data-hook="admin_price_list_edit_form">
+  <%= form_for [:admin, @price_list] do |f| %>
+    <fieldset class="no-border-top">
+      <%= render partial: 'form', locals: { f: f } %>
+
+      <div class="clear"></div>
+
+      <%= render partial: 'price_list_info', locals: { price_list: @price_list } %>
+
+      <div data-hook="admin_price_list_edit_form_buttons">
+        <%= render partial: 'spree/admin/shared/edit_resource_links' %>
+      </div>
+    </fieldset>
+  <% end %>
+</div>

--- a/backend/app/views/spree/admin/price_lists/index.html.erb
+++ b/backend/app/views/spree/admin/price_lists/index.html.erb
@@ -1,0 +1,47 @@
+<% admin_breadcrumb(link_to plural_resource_name(Spree::Product), spree.admin_products_path) %>
+<% admin_breadcrumb(plural_resource_name(Spree::PriceList)) %>
+
+<% content_for :page_actions do %>
+  <% if can?(:create, Spree::PriceList) %>
+    <li>
+      <%= link_to t('spree.new_price_list'), new_object_url, id: 'admin_new_price_list_link', class: 'btn btn-primary' %>
+    </li>
+  <% end %>
+<% end %>
+
+<% if @price_lists.any? %>
+  <table class="index" id='listing_price_lists'>
+    <colgroup>
+      <col style="width: 40%">
+      <col style="width: 20%">
+    </colgroup>
+    <thead>
+      <tr data-hook="admin_price_lists_index_headers">
+        <th><%= Spree::PriceList.human_attribute_name(:name) %></th>
+        <th data-hook="admin_price_lists_index_header_actions" class="actions"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @price_lists.each do |price_list| %>
+        <tr id="<%= spree_dom_id price_list %>" data-hook="admin_price_lists_index_rows">
+          <td><%= link_to price_list.try(:name), edit_admin_price_list_path(price_list) %></td>
+          <td data-hook="admin_price_lists_index_row_actions" class="actions">
+            <% if can?(:update, price_list) %>
+              <%= link_to_edit price_list, no_text: true %>
+            <% end %>
+
+            <% if can?(:destroy, price_list) %>
+              <%= link_to_delete price_list, no_text: true %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class="no-objects-found">
+    <%= render 'spree/admin/shared/no_objects_found',
+                 resource: Spree::PriceList,
+                 new_resource_url: new_object_url %>
+  </div>
+<% end %>

--- a/backend/app/views/spree/admin/price_lists/new.html.erb
+++ b/backend/app/views/spree/admin/price_lists/new.html.erb
@@ -1,0 +1,24 @@
+<% admin_breadcrumb(link_to plural_resource_name(Spree::Product), spree.admin_products_path) %>
+<% admin_breadcrumb(link_to plural_resource_name(Spree::PriceList), spree.admin_price_lists_path) %>
+<% admin_breadcrumb(t('spree.new_price_list')) %>
+
+<% content_for :page_actions do %>
+<% end %>
+
+<div data-hook="admin_price_list_new_form_header">
+  <%= render partial: 'spree/shared/error_messages', locals: { target: @price_list } %>
+</div>
+
+<div data-hook="admin_price_list_new_form">
+  <%= form_for [:admin, @price_list] do |f| %>
+    <fieldset class="no-border-top">
+      <%= render partial: 'form', locals: { f: f } %>
+
+      <div class="clear"></div>
+
+      <div data-hook="admin_price_list_new_form_buttons">
+        <%= render partial: 'spree/admin/shared/new_resource_links' %>
+      </div>
+    </fieldset>
+  <% end %>
+</div>

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -43,6 +43,13 @@
           <% end %>
         </div>
 
+        <div data-hook="admin_product_form_brand_taxons">
+        <%= f.field_container :brand_taxon do %>
+          <%= f.label :brand_taxon_id %><br>
+          <%= f.hidden_field :brand_taxon_id, value: @product.brand_taxon_id %>
+        <% end %>
+      </div>
+
         <div data-hook="admin_product_form_option_types">
           <%= f.field_container :option_types do %>
             <%= f.label :option_type_ids, plural_resource_name(Spree::OptionType) %>

--- a/backend/app/views/spree/admin/shared/_product_sub_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_product_sub_menu.html.erb
@@ -4,6 +4,9 @@
   <% if can? :admin, Spree::Product %>
     <%= tab label: :products, match_path: '/products' %>
   <% end %>
+  <% if can? :admin, Spree::PriceList %>
+    <%= tab label: :price_lists, match_path: '/price_lists' %>
+  <% end %>
   <% if can? :admin, Spree::OptionType %>
     <%= tab label: :option_types, match_path: '/option_types' %>
   <% end %>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -16,6 +16,10 @@ Spree::Core::Engine.routes.draw do
 
     resources :zones
 
+    resources :price_lists do
+      resources :price_list_items, only: [:destroy, :edit, :update, :new, :create]
+    end
+
     resources :tax_categories
 
     resources :products do

--- a/backend/lib/spree/backend_configuration.rb
+++ b/backend/lib/spree/backend_configuration.rb
@@ -199,6 +199,13 @@ module Spree
               match_path: '/products',
             ),
             MenuItem.new(
+              label: :price_lists,
+              condition: -> {
+                can?(:admin, Spree::PriceList)
+              },
+              match_path: '/price_lists'
+            ),
+            MenuItem.new(
               label: :option_types,
               condition: -> { can? :admin, Spree::OptionType },
               match_path: '/option_types',

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -9,6 +9,9 @@ module Spree
     belongs_to :variant, -> { with_discarded }, class_name: 'Spree::Variant', touch: true, optional: true
     belongs_to :country, class_name: "Spree::Country", foreign_key: "country_iso", primary_key: "iso", optional: true
 
+    has_many :price_list_items, class_name: 'Spree::PriceListItem'
+    has_many :price_lists, through: :price_list_items, class_name: 'Spree::PriceList'
+
     delegate :product, to: :variant
     delegate :tax_rates, to: :variant
 

--- a/core/app/models/spree/price_list.rb
+++ b/core/app/models/spree/price_list.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Spree
+  class PriceList < Spree::Base
+    has_many :price_list_items, class_name: 'Spree::PriceListItem', dependent: :destroy
+    has_many :prices, through: :price_list_items, class_name: 'Spree::Price'
+    belongs_to :country, class_name: "Spree::Country", foreign_key: "country_iso", primary_key: "iso", optional: true
+
+    validates :currency, inclusion: { in: ::Money::Currency.all.map(&:iso_code), message: :invalid_code }
+    validates :country, presence: true, unless: -> { for_any_country? }
+
+    validates :name, presence: true
+
+    def for_any_country?
+      country_iso.nil?
+    end
+
+    def country_iso=(country_iso)
+      self[:country_iso] = country_iso.presence
+    end
+  end
+end

--- a/core/app/models/spree/price_list_item.rb
+++ b/core/app/models/spree/price_list_item.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Spree
+  class PriceListItem < Spree::Base
+    belongs_to :price_list, class_name: 'Spree::PriceList'
+    belongs_to :price, class_name: 'Spree::Price', dependent: :destroy
+
+    validates :price_list, presence: true
+    validates :price, presence: true
+
+    accepts_nested_attributes_for :price
+  end
+end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -33,6 +33,7 @@ module Spree
     belongs_to :tax_category, class_name: 'Spree::TaxCategory', optional: true
     belongs_to :shipping_category, class_name: 'Spree::ShippingCategory', inverse_of: :products, optional: true
     belongs_to :primary_taxon, class_name: 'Spree::Taxon', optional: true
+    belongs_to :brand_taxon, class_name: 'Spree::Taxon', optional: true
 
     has_one :master,
       -> { where(is_master: true).with_discarded },

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -166,6 +166,8 @@ en:
         variant: Variant
       spree/product:
         available_on: Available On
+        brand_taxon: Brand Taxon
+        brand_taxon_id: Brand Taxon
         condition: Master Condition
         cost_currency: Cost Currency
         cost_price: Cost Price

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -480,6 +480,10 @@ en:
           attributes:
             currency:
               invalid_code: is not a valid currency code
+        spree/price_list:
+          attributes:
+            currency:
+              invalid_code: is not a valid currency code
         spree/promotion:
           attributes:
             apply_automatically:
@@ -648,6 +652,9 @@ en:
       spree/price:
         one: Price
         other: Prices
+      spree/price_list:
+        one: Price List
+        other: Price Lists
       spree/product:
         one: Product
         other: Products
@@ -872,6 +879,16 @@ en:
         source_forms:
           storecredit:
             not_supported: Creating store credit payments via the admin is not currently supported.
+      price_list_items:
+        edit:
+          edit_price: Edit Price
+        new:
+          new_price: New Price
+      price_lists:
+        edit:
+          new_price: Add New Price
+        price_list_info:
+          price_details: Price Details
       prices:
         any_country: Any Country
         edit:
@@ -950,6 +967,8 @@ en:
         orders: Orders
         overview: Overview
         payments: Payments
+        price_list: Price List
+        price_lists: Price Lists
         products: Products
         properties: Property Types
         rma: RMA
@@ -1151,6 +1170,7 @@ en:
     confirm_delete: Confirm Deletion
     confirm_order: Confirm Order
     confirm_password: Password Confirmation
+    contain_taxes: Tax Included
     continue: Continue
     continue_shopping: Continue shopping
     cost_currency: Cost Currency
@@ -1611,6 +1631,9 @@ en:
         country: 'This determines in what country the price is valid.<br>Default: Any Country'
         master_variant: Changing master variant prices will not change variant prices below, but will be used to populate all new variants
         options: These options are used to create variants in the variants table. They can be changed in the variants tab
+      spree/price_list:
+        country: 'This determines in what country the price is valid.<br>Default: Any Country'
+        currency: This determines which currency will be used for the price list's prices. Please, be aware that this will be used while adding prices to the price list's.
       spree/product:
         available_on: This sets the availability date for the product. If this value is not set, or it is set to a date in the future, then the product is not available on the storefront.
         discontinue_on: This sets the discontinue date for the product. If this value is set to a date, then the product is not available on the storefront from that day on anymore.
@@ -1789,6 +1812,7 @@ en:
     new_order_completed: New Order Completed
     new_payment: New Payment
     new_payment_method: New Payment Method
+    new_price_list: New Price List
     new_product: New Product
     new_property: New Property Type
     new_refund: New Refund

--- a/core/db/migrate/20250327105244_create_price_lists.rb
+++ b/core/db/migrate/20250327105244_create_price_lists.rb
@@ -1,0 +1,12 @@
+class CreatePriceLists < ActiveRecord::Migration[7.0]
+  def change
+    create_table :spree_price_lists do |t|
+      t.string :name
+      t.string :country_iso, limit: 2
+      t.string :currency
+      t.boolean :contain_taxes, default: false
+      t.index ["country_iso"], name: "index_spree_price_lists_on_country_iso"
+      t.timestamps
+    end
+  end
+end

--- a/core/db/migrate/20250327105341_create_price_list_items.rb
+++ b/core/db/migrate/20250327105341_create_price_list_items.rb
@@ -1,0 +1,9 @@
+class CreatePriceListItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :spree_price_list_items do |t|
+      t.references :price_list, foreign_key: {to_table: :spree_price_lists}
+      t.references :price, foreign_key: { to_table: :spree_prices }
+      t.timestamps
+    end
+  end
+end

--- a/core/db/migrate/20250408152004_add_brand_taxon_to_products.rb
+++ b/core/db/migrate/20250408152004_add_brand_taxon_to_products.rb
@@ -1,0 +1,7 @@
+class AddBrandTaxonToProducts < ActiveRecord::Migration[7.0]
+  def change
+    change_table :spree_products do |t|
+      t.references :brand_taxon, type: :integer, foreign_key: { to_table: :spree_taxons }
+    end
+  end
+end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -82,7 +82,7 @@ module Spree
       :option_values_hash, :weight, :height, :width, :depth,
       :shipping_category_id, :tax_category_id,
       :taxon_ids, :option_type_ids, :cost_currency, :cost_price, :primary_taxon_id,
-      :gtin, :condition
+      :gtin, :condition, :brand_taxon_id
     ]
 
     @@property_attributes = [:name, :presentation]

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -483,6 +483,22 @@ RSpec.describe Spree::Product, type: :model do
           expect(association.class_name).to eq('Spree::Taxon')
         end
       end
+
+      describe "brand_taxon" do
+        it 'should belong to brand_taxon' do
+          expect(Spree::Product.reflect_on_association(:brand_taxon).macro).to eq(:belongs_to)
+        end
+
+        it 'should be optional' do
+          association = Spree::Product.reflect_on_association(:brand_taxon)
+          expect(association.options[:optional]).to be(true)
+        end
+
+        it 'should have a class_name of Spree::Taxon' do
+          association = Spree::Product.reflect_on_association(:brand_taxon)
+          expect(association.class_name).to eq('Spree::Taxon')
+        end
+      end
     end
   end
 
@@ -745,6 +761,14 @@ RSpec.describe Spree::Product, type: :model do
     product_with_taxon = create(:product, primary_taxon: create(:taxon))
 
     product_without_taxon = create(:product, primary_taxon: nil)
+
+    expect(product_with_taxon).to be_valid
+    expect(product_without_taxon).to be_valid
+  end
+  it 'is valid with or without a brand_taxon' do
+    product_with_taxon = create(:product, brand_taxon: create(:taxon))
+
+    product_without_taxon = create(:product, brand_taxon: nil)
 
     expect(product_with_taxon).to be_valid
     expect(product_without_taxon).to be_valid


### PR DESCRIPTION
### Description

This pull request introduces several enhancements to the Spree Admin interface, allowing for more efficient management of pricing. 

**Key Changes**:

- **Price List Management**: 
  - Users can now create and manage price lists directly from the admin panel. This includes the ability to add new prices associated with specific price lists, streamlining the pricing process.
  
- **Price List Items**: 
  - Administrators can create new price list items directly from the price list interface, making it easier to manage pricing details for products.

- **Improved Navigation**: 
  - The admin navigation has been updated to include links to price lists, ensuring that these features are easily accessible.

These enhancements improve the overall organization of the admin interface, making it easier for administrators to manage prices effectively. 

**Benefits**:
- Streamlined pricing management with the ability to create prices directly from the price list.