### PR TITLE
Add User group functionality on admin and  automatically associate users to groups upon signup

### DIFF
--- a/backend/app/controllers/spree/admin/user_groups_controller.rb
+++ b/backend/app/controllers/spree/admin/user_groups_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Spree
+  module Admin
+    class UserGroupsController < ResourceController
+      before_action :load_data, except: :index
+
+      private
+
+      def load_data
+        @price_list = Spree::PriceList.order(:name)
+      end
+    end
+  end
+end

--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -111,6 +111,10 @@ module Spree
           attributes -= [:password, :password_confirmation]
         end
 
+        if can? :manage, Spree::UserGroup
+          attributes += [:user_group_id]
+        end
+
         params.require(:user).permit(attributes)
       end
 

--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -25,6 +25,7 @@ module Spree
         if @user.save
           set_roles
           set_stock_locations
+          set_user_group if current_store&.enforce_group_upon_signup
 
           flash[:success] = t('spree.created_successfully')
           redirect_to edit_admin_user_url(@user)
@@ -155,6 +156,13 @@ module Spree
         if user_params[:stock_location_ids]
           @user.stock_locations =
             Spree::StockLocation.accessible_by(current_ability).where(id: user_params[:stock_location_ids])
+        end
+      end
+
+      def set_user_group
+        if @user && @user.user_group.nil?
+          user_group = current_store.default_cart_user_group
+          @user.update(user_group: user_group) if user_group
         end
       end
     end

--- a/backend/app/views/spree/admin/price_lists/index.html.erb
+++ b/backend/app/views/spree/admin/price_lists/index.html.erb
@@ -13,11 +13,13 @@
   <table class="index" id='listing_price_lists'>
     <colgroup>
       <col style="width: 40%">
+      <col style="width: 40%">
       <col style="width: 20%">
     </colgroup>
     <thead>
       <tr data-hook="admin_price_lists_index_headers">
         <th><%= Spree::PriceList.human_attribute_name(:name) %></th>
+        <th><%= Spree::UserGroup.model_name.human.pluralize %></th>
         <th data-hook="admin_price_lists_index_header_actions" class="actions"></th>
       </tr>
     </thead>
@@ -25,6 +27,11 @@
       <% @price_lists.each do |price_list| %>
         <tr id="<%= spree_dom_id price_list %>" data-hook="admin_price_lists_index_rows">
           <td><%= link_to price_list.try(:name), edit_admin_price_list_path(price_list) %></td>
+          <td>
+            <span title="<%= price_list.user_groups.map(&:group_name).join(', ') %>">
+              <%= price_list.user_groups.count %> <%= Spree::UserGroup.model_name.human.pluralize %>
+            </span>
+          </td>
           <td data-hook="admin_price_lists_index_row_actions" class="actions">
             <% if can?(:update, price_list) %>
               <%= link_to_edit price_list, no_text: true %>

--- a/backend/app/views/spree/admin/shared/users_sub_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/users_sub_menu.html.erb
@@ -1,0 +1,11 @@
+<% Spree.deprecator.warn "Using the #{@virtual_path.inspect} partial is deprecated, please use MenuItem#children instead." %>
+
+<ul class="admin-subnav" data-hook="admin_users_sub_tabs">
+  <% if can?(:admin, Spree.user_class) %>
+    <%= tab label: :users, url: spree.admin_users_path %>
+  <% end %>
+
+  <% if can?(:admin, Spree::UserGroup) %>
+    <%= tab label: :user_groups, url: spree.admin_user_groups_path %>
+  <% end %>
+</ul>

--- a/backend/app/views/spree/admin/stores/_form.html.erb
+++ b/backend/app/views/spree/admin/stores/_form.html.erb
@@ -30,6 +30,13 @@
       <%= f.text_area :meta_description, class: 'fullwidth' %>
       <%= f.error_message_on :meta_description %>
     <% end %>
+
+    <%= f.field_container :default_cart_user_group_id do %>
+      <%= f.label :default_cart_user_group_id %>
+      <%= f.collection_select :default_cart_user_group_id, Spree::UserGroup.all, :id, :group_name, { include_blank: true }, { class: 'custom-select' } %>
+      <%= f.error_message_on :default_cart_user_group_id %>
+    <% end %>
+
   </div>
   <div class="col-12 col-md-6">
     <%= f.field_container :url do %>

--- a/backend/app/views/spree/admin/stores/_form.html.erb
+++ b/backend/app/views/spree/admin/stores/_form.html.erb
@@ -37,6 +37,13 @@
       <%= f.error_message_on :default_cart_user_group_id %>
     <% end %>
 
+    <%= f.field_container :enforce_group_upon_signup, class: %w(checkbox) do %>
+      <label>
+        <%= f.check_box(:enforce_group_upon_signup) %>
+        <%= t('spree.enforce_group_upon_signup') %>
+      </label>
+      <%= f.error_message_on :enforce_group_upon_signup %>
+    <% end %>
   </div>
   <div class="col-12 col-md-6">
     <%= f.field_container :url do %>

--- a/backend/app/views/spree/admin/user_groups/_form.html.erb
+++ b/backend/app/views/spree/admin/user_groups/_form.html.erb
@@ -1,0 +1,17 @@
+<div data-hook="admin_user_group_form_fields" class="row">
+  <div data-hook="admin_user_group_form_group_name_field" class="col-5">
+    <%= f.field_container :group_name do %>
+      <%= f.label :group_name, class: 'required' %>
+      <%= f.text_field :group_name, class: 'fullwidth' %>
+      <%= error_message_on :user_group, :group_name %>
+    <% end %>
+  </div>
+
+  <div data-hook="admin_user_group_form_price_list_field" class="col-5">
+    <%= f.field_container :price_list_id do %>
+      <%= f.label :price_list_id %><br>
+      <%= f.collection_select :price_list_id, @price_list, :id, :name, { include_blank: true }, { class: "custom-select" } %>
+      <%= error_message_on :user_group, :price_list_id %>
+    <% end %>
+  </div>
+</div>

--- a/backend/app/views/spree/admin/user_groups/edit.html.erb
+++ b/backend/app/views/spree/admin/user_groups/edit.html.erb
@@ -1,0 +1,24 @@
+<% admin_breadcrumb(link_to plural_resource_name(Spree::LegacyUser), spree.admin_users_path) %>
+<% admin_breadcrumb(link_to plural_resource_name(Spree::UserGroup), spree.admin_user_groups_path) %>
+<% admin_breadcrumb(@user_group.group_name) %>
+
+<% content_for :page_actions do %>
+<% end %>
+
+<div data-hook="admin_user_group_edit_form_header">
+  <%= render partial: 'spree/shared/error_messages', locals: { target: @user_group } %>
+</div>
+
+<div data-hook="admin_user_group_edit_form">
+  <%= form_for [:admin, @user_group] do |f| %>
+    <fieldset class="no-border-top">
+      <%= render partial: 'form', locals: { f: f } %>
+
+      <div class="clear"></div>
+
+      <div data-hook="admin_user_group_edit_form_buttons">
+        <%= render partial: 'spree/admin/shared/edit_resource_links' %>
+      </div>
+    </fieldset>
+  <% end %>
+</div>

--- a/backend/app/views/spree/admin/user_groups/index.html.erb
+++ b/backend/app/views/spree/admin/user_groups/index.html.erb
@@ -1,0 +1,50 @@
+<% admin_breadcrumb(link_to plural_resource_name(Spree::LegacyUser), spree.admin_users_path) %>
+<% admin_breadcrumb(plural_resource_name(Spree::UserGroup)) %>
+
+<% content_for :page_actions do %>
+  <% if can?(:create, Spree::UserGroup) %>
+    <li>
+      <%= link_to t('spree.new_user_group'), new_object_url, id: 'admin_new_user_group_link', class: 'btn btn-primary' %>
+    </li>
+  <% end %>
+<% end %>
+
+<% if @user_groups.any? %>
+  <table class="index" id='listing_user_groups'>
+    <colgroup>
+      <col style="width: 40%">
+      <col style="width: 40%">
+      <col style="width: 20%">
+    </colgroup>
+    <thead>
+      <tr data-hook="admin_user_groups_index_headers">
+        <th><%= Spree::UserGroup.human_attribute_name(:group_name) %></th>
+        <th><%= Spree::PriceList.model_name.human %></th>
+        <th data-hook="admin_user_groups_index_header_actions" class="actions"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @user_groups.each do |user_group| %>
+        <tr id="<%= spree_dom_id user_group %>" data-hook="admin_user_groups_index_rows">
+          <td><%= link_to user_group.try(:group_name), edit_admin_user_group_path(user_group) %></td>
+          <td><%= user_group.price_list.try(:name) %></td>
+          <td data-hook="admin_user_groups_index_row_actions" class="actions">
+            <% if can?(:update, user_group) %>
+              <%= link_to_edit user_group, no_text: true %>
+            <% end %>
+
+            <% if can?(:destroy, user_group) %>
+              <%= link_to_delete user_group, no_text: true %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class="no-objects-found">
+    <%= render 'spree/admin/shared/no_objects_found',
+                 resource: Spree::UserGroup,
+                 new_resource_url: new_object_url %>
+  </div>
+<% end %>

--- a/backend/app/views/spree/admin/user_groups/new.html.erb
+++ b/backend/app/views/spree/admin/user_groups/new.html.erb
@@ -1,0 +1,24 @@
+<% admin_breadcrumb(link_to plural_resource_name(Spree::LegacyUser), spree.admin_users_path) %>
+<% admin_breadcrumb(link_to plural_resource_name(Spree::UserGroup), spree.admin_user_groups_path) %>
+<% admin_breadcrumb(t('spree.new_user_group')) %>
+
+<% content_for :page_actions do %>
+<% end %>
+
+<div data-hook="admin_user_group_new_form_header">
+  <%= render partial: 'spree/shared/error_messages', locals: { target: @user_group } %>
+</div>
+
+<div data-hook="admin_user_group_new_form">
+  <%= form_for [:admin, @user_group] do |f| %>
+    <fieldset class="no-border-top">
+      <%= render partial: 'form', locals: { f: f } %>
+
+      <div class="clear"></div>
+
+      <div data-hook="admin_user_group_new_form_buttons">
+        <%= render partial: 'spree/admin/shared/new_resource_links' %>
+      </div>
+    </fieldset>
+  <% end %>
+</div>

--- a/backend/app/views/spree/admin/users/_form.html.erb
+++ b/backend/app/views/spree/admin/users/_form.html.erb
@@ -78,3 +78,15 @@
     <% end %>
   </div>
 </div>
+<% if can?(:update, @user) && can?(:manage, :user_group) %>
+  <fieldset data-hook="admin_user_user_group" id="admin_user_edit_user_group">
+    <legend><%= t('spree.admin.user.user_group') %></legend>
+    <div>
+      <%= f.field_container :user_group_id do %>
+        <%= f.label :user_group_id, t('spree.admin.user.user_group') %>
+        <%= f.collection_select :user_group_id, Spree::UserGroup.all, :id, :group_name, { include_blank: true }, { class: 'custom-select' } %>
+        <%= f.error_message_on :user_group_id %>
+      <% end %>
+    </div>
+  </fieldset>
+<% end %>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -20,6 +20,7 @@ Spree::Core::Engine.routes.draw do
       resources :price_list_items, only: [:destroy, :edit, :update, :new, :create]
     end
 
+    resources :user_groups
     resources :tax_categories
 
     resources :products do

--- a/backend/lib/spree/backend_configuration.rb
+++ b/backend/lib/spree/backend_configuration.rb
@@ -237,8 +237,24 @@ module Spree
           label: :users,
           icon: admin_updated_navbar ? 'ri-user-line' : 'user',
           match_path: %r{/(users|store_credits)},
+          data_hook: :admin_users_sub_tabs,
+          partial: 'spree/admin/shared/users_sub_menu',
           condition: -> { Spree.user_class && can?(:admin, Spree.user_class) },
           url: :admin_users_path,
+          children: [
+            MenuItem.new(
+              label: :users,
+              condition: -> { Spree.user_class && can?(:admin, Spree.user_class) },
+              url: :admin_users_path
+            ),
+            MenuItem.new(
+              label: :user_groups,
+              condition: -> {
+                can?(:admin, Spree::UserGroup)
+              },
+              url: :admin_user_groups_path
+            ),
+          ]
         ),
         MenuItem.new(
           label: :settings,

--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -26,6 +26,7 @@ module Spree
       has_many :credit_cards, class_name: "Spree::CreditCard", foreign_key: :user_id
       has_many :wallet_payment_sources, foreign_key: 'user_id', class_name: 'Spree::WalletPaymentSource', inverse_of: :user
 
+      belongs_to :user_group, class_name: 'Spree::UserGroup', optional: true
       after_create :auto_generate_spree_api_key
       before_destroy :check_for_deletion
 

--- a/core/app/models/spree/price_list.rb
+++ b/core/app/models/spree/price_list.rb
@@ -4,6 +4,7 @@ module Spree
   class PriceList < Spree::Base
     has_many :price_list_items, class_name: 'Spree::PriceListItem', dependent: :destroy
     has_many :prices, through: :price_list_items, class_name: 'Spree::Price'
+    has_many :user_groups, class_name: 'Spree::UserGroup', dependent: :destroy
     belongs_to :country, class_name: "Spree::Country", foreign_key: "country_iso", primary_key: "iso", optional: true
 
     validates :currency, inclusion: { in: ::Money::Currency.all.map(&:iso_code), message: :invalid_code }

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -17,6 +17,8 @@ module Spree
 
     has_many :orders, class_name: "Spree::Order"
 
+    belongs_to :default_cart_user_group, class_name: 'Spree::UserGroup', optional: true
+
     validates :code, presence: true, uniqueness: { allow_blank: true, case_sensitive: true }
     validates :name, presence: true
     validates :url, presence: true

--- a/core/app/models/spree/user_group.rb
+++ b/core/app/models/spree/user_group.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Spree
+  class UserGroup < Spree::Base
+    has_many :users, class_name: Spree::UserClassHandle.new
+    has_one :store, class_name: 'Spree::Store', foreign_key: 'default_cart_user_group_id'
+    belongs_to :price_list, class_name: 'Spree::PriceList', optional: true
+
+    validates :group_name, presence: true
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1556,6 +1556,7 @@ en:
     enable_mail_delivery: Enable Mail Delivery
     end: End
     ending_in: Ending in
+    enforce_group_upon_signup: Add all new users to Group
     error: error
     error_user_destroy_with_orders: Cannot delete a user with orders
     errors:

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -361,6 +361,7 @@ en:
         cart_tax_country_iso: Tax Country for Empty Carts
         code: Slug
         default: Default
+        default_cart_user_group_id: Default User Group
         default_currency: Default Currency
         mail_from_address: Mail From Address
         meta_description: Meta Description
@@ -766,6 +767,9 @@ en:
       spree/user:
         one: User
         other: Users
+      spree/user_group:
+        one: User Group
+        other: User Groups
       spree/variant:
         one: Variant
         other: Variants
@@ -980,6 +984,7 @@ en:
         taxes: Taxes
         taxonomies: Taxonomies
         taxons: Taxons
+        user_groups: User Groups
         users: Users
         zones: Zones
       taxons:
@@ -993,6 +998,7 @@ en:
         order_num: 'Order #'
         orders: Orders
         store_credit: Store Credit
+        user_group: User Group
         user_information: User Information
       users:
         edit:
@@ -1834,6 +1840,7 @@ en:
     new_taxonomy: New Taxonomy
     new_tracker: New Analytics Tracker
     new_user: New User
+    new_user_group: New User Group
     new_variant: New Variant
     new_zone: New Zone
     next: Next

--- a/core/db/migrate/20250328060032_create_user_groups.rb
+++ b/core/db/migrate/20250328060032_create_user_groups.rb
@@ -1,0 +1,10 @@
+class CreateUserGroups < ActiveRecord::Migration[7.0]
+  def change
+    create_table :spree_user_groups do |t|
+      t.string :group_name
+      t.references :price_list, foreign_key: { to_table: :spree_price_lists }
+
+      t.timestamps
+    end
+  end
+end

--- a/core/db/migrate/20250328083320_add_user_group_id_to_users.rb
+++ b/core/db/migrate/20250328083320_add_user_group_id_to_users.rb
@@ -1,0 +1,7 @@
+class AddUserGroupIdToUsers < ActiveRecord::Migration[7.0]
+  def change
+    change_table Spree.user_class.table_name do |t|
+      t.references :user_group, type: :integer, foreign_key: { to_table: :spree_user_groups }
+    end
+  end
+end

--- a/core/db/migrate/20250402065610_add_default_user_group_to_stores.rb
+++ b/core/db/migrate/20250402065610_add_default_user_group_to_stores.rb
@@ -1,0 +1,8 @@
+class AddDefaultUserGroupToStores < ActiveRecord::Migration[7.0]
+  def change
+    change_table :spree_stores do |t|
+      t.references :default_cart_user_group, type: :integer, foreign_key: { to_table: :spree_user_groups }
+      t.boolean :enforce_group_upon_signup, default: false
+    end
+  end
+end


### PR DESCRIPTION
### Description

This pull request introduces several enhancements to the Spree Admin interface, allowing for more efficient management  of user groups. 

**Key Changes**:

- **User  Groups Management**: 
  - A new user groups feature has been added, allowing administrators to create and manage user groups. This enables targeted pricing strategies based on user group assignments.

- **Improved Navigation**: 
  - The admin navigation has been updated to include links to user groups, ensuring that these features are easily accessible.

These enhancements improve the overall organization of the admin interface, making it easier for administrators to manage  user groups effectively. 

**Benefits**:
- Enhanced user management through user groups, allowing for more flexible pricing strategies.