### PR TITLE
Add a new column to prices to avoid editing pricing from the product interface if the price has been generated through a pricelist interface

### DIFF
--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -22,3 +22,5 @@ en:
         transfer_success: Variants successfully transferred
       stock_not_below_zero: Stock must not be below zero.
       unauthorized: You are not authorized to perform that action.
+      price_belongs_to_pricelist: Price belongs to price list and cannot be edited or deleted from product page
+

--- a/backend/app/controllers/spree/admin/prices_controller.rb
+++ b/backend/app/controllers/spree/admin/prices_controller.rb
@@ -4,6 +4,7 @@ module Spree
   module Admin
     class PricesController < ResourceController
       belongs_to 'spree/product', find_by: :slug
+      before_action :check_pricelist_price, only: [:edit, :update, :destroy]
 
       def index
         params[:q] ||= {}
@@ -22,6 +23,15 @@ module Spree
       end
 
       def edit
+      end
+
+      private
+
+      def check_pricelist_price
+        if @price.is_pricelist_price
+          flash[:error] = t('spree.admin.prices.errors.price_belongs_to_pricelist')
+          redirect_to admin_product_prices_path(@product)
+        end
       end
     end
   end

--- a/backend/app/views/spree/admin/price_list_items/_form.html.erb
+++ b/backend/app/views/spree/admin/price_list_items/_form.html.erb
@@ -20,6 +20,17 @@
       <%= f.label :price %>
       <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :price, currency_attr: :currency, currency: @price_list.currency %>
     </div>
+
+    <div data-hook="admin_price_list_item_price_form_contain_taxes" class="col-5">
+      <%= field_container :contain_taxes, class: %w(checkbox) do %>
+        <label>
+          <%= f.check_box(:contain_taxes) %>
+          <%= t('spree.contain_taxes') %>
+        </label>
+        <%= error_message_on :price_list, :contain_taxes %>
+      <% end %>
+    </div>
+      <%= f.hidden_field :is_pricelist_price, value: true %>
   </div>
 </div>
 <div class="clear"></div>

--- a/backend/app/views/spree/admin/prices/_master_variant_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_master_variant_table.html.erb
@@ -25,12 +25,16 @@
         <td><%= price.currency %></td>
         <td><%= price.money.to_html %></td>
         <td class="actions">
-          <% if can?(:edit, price) %>
+          <% if can?(:edit, price) && !price.is_pricelist_price %>
             <%= link_to_edit(price, no_text: true) unless price.discarded? %>
           <% end %>
-          <% if can?(:destroy, price) %>
+          <% if can?(:destroy, price) && !price.is_pricelist_price %>
             &nbsp;
             <%= link_to_delete(price, no_text: true) unless price.discarded? %>
+          <% end %>
+          <% if price.is_pricelist_price  %>
+            &nbsp;
+            <%= Spree::PriceList.model_name.human %>: <%= price.price_lists.map(&:name).join(', ') %>
           <% end %>
         </td>
       </tr>

--- a/backend/app/views/spree/admin/prices/_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_table.html.erb
@@ -20,12 +20,16 @@
           <td><%= price.currency %></td>
           <td><%= price.money.to_html %></td>
           <td class="actions">
-            <% if can?(:edit, price) %>
+            <% if can?(:edit, price) && !price.is_pricelist_price %>
               <%= link_to_edit(price, no_text: true) unless price.discarded? %>
             <% end %>
-            <% if can?(:destroy, price) %>
+            <% if can?(:destroy, price) && !price.is_pricelist_price  %>
               &nbsp;
               <%= link_to_delete(price, no_text: true) unless price.discarded? %>
+            <% end %>
+            <% if price.is_pricelist_price  %>
+              &nbsp;
+              <%= Spree::PriceList.model_name.human %>: <%= price.price_lists.map(&:name).join(', ') %>
             <% end %>
           </td>
         </tr>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -897,6 +897,8 @@ en:
         any_country: Any Country
         edit:
           edit_price: Edit Price
+        errors:
+          price_belongs_to_pricelist: Price belongs to price list and cannot be edited or deleted from product page
         index:
           amount_greater_than: Amount greater than
           amount_less_than: Amount less than

--- a/core/db/migrate/20250408053234_add_contain_taxes_and_is_pricelist_price_to_prices.rb
+++ b/core/db/migrate/20250408053234_add_contain_taxes_and_is_pricelist_price_to_prices.rb
@@ -1,0 +1,6 @@
+class AddContainTaxesAndIsPricelistPriceToPrices < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_prices, :contain_taxes, :boolean, default: false
+    add_column :spree_prices, :is_pricelist_price, :boolean, default: false
+  end
+end


### PR DESCRIPTION
### Description

This pull request introduces several enhancements to the pricing management system within the Spree application, focusing on the integration of price lists. The changes aim to improve data integrity and user experience by preventing unintended modifications to prices associated with price lists.

**Key Changes**:

1. **New Attributes for Prices**:
   - Added `contain_taxes` and `is_pricelist_price` attributes to the Spree price model. These attributes facilitate better management of pricing, particularly in relation to tax handling and price list associations.

2. **Price List Price Check**:
   - Implemented a `check_pricelist_price` method in both the variant API and the admin prices controller. This method prevents users from updating or deleting prices that are associated with a price list, ensuring the integrity of pricing data.

3. **Localization and User Feedback**:
   - Added a new localization key for error messages that inform users when a price cannot be edited or deleted due to its association with a price list.
   - Updated the admin interface to:
     - Prevent editing and deleting of prices that belong to a price list.
     - Display a message indicating the associated price lists for prices that are part of a price list.

**Benefits**:
- Enhances user feedback and clarity in the admin interface.
- Protects prices tied to price lists from unintended modifications.
- Improves overall pricing management experience for administrators.
