### PR TITLE
Restrict pricelist price update from product page

### DIFF
--- a/api/app/controllers/spree/api/variants_controller.rb
+++ b/api/app/controllers/spree/api/variants_controller.rb
@@ -4,6 +4,7 @@ module Spree
   module Api
     class VariantsController < Spree::Api::BaseController
       before_action :product
+      before_action :check_pricelist_price, only: [:update, :destroy]
 
       def create
         authorize! :create, Variant
@@ -90,6 +91,18 @@ module Spree
 
       def include_list
         [{ option_values: :option_type }, :product, :prices, :images, { stock_items: :stock_location }]
+      end
+
+      # Checks if variant's price is a pricelist price (is_pricelist_price == true), returns an error
+      # Otherwise allows update/deletion to proceed
+      def check_pricelist_price
+        @variant = scope.find(params[:id])
+        pricing_options = Spree::Config.default_pricing_options
+        price_object = @variant.price_for_options(pricing_options)
+
+        if price_object.is_pricelist_price
+          render json: { error: t('spree.api.price_belongs_to_pricelist') }, status: 422
+        end
       end
     end
   end

--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -16,6 +16,7 @@ en:
       payment:
         credit_over_limit: This payment can only be credited up to %{limit}. Please specify an amount less than or equal to this number.
         update_forbidden: This payment cannot be updated because it is %{state}.
+      price_belongs_to_pricelist: Price belongs to price list and cannot be edited or deleted from product page
       resource_not_found: The resource you were looking for could not be found.
       shipment:
         cannot_ready: Cannot ready shipment.

--- a/backend/app/controllers/spree/admin/prices_controller.rb
+++ b/backend/app/controllers/spree/admin/prices_controller.rb
@@ -4,6 +4,7 @@ module Spree
   module Admin
     class PricesController < ResourceController
       belongs_to 'spree/product', find_by: :slug
+      before_action :check_pricelist_price, only: [:edit, :update, :destroy]
 
       def index
         params[:q] ||= {}
@@ -22,6 +23,19 @@ module Spree
       end
 
       def edit
+      end
+
+      private
+
+      # Redirects with an error message if the price has is_pricelist_price set to true.
+      # which indicates that the price is part of a pricelist. This is to prevent
+      # modification or deletion of prices that are part of a pricelist via the
+      # product price interface.
+      def check_pricelist_price
+        if @price.is_pricelist_price
+          flash[:error] = t('spree.admin.prices.errors.price_belongs_to_pricelist')
+          redirect_to admin_product_prices_path(@product)
+        end
       end
     end
   end

--- a/backend/app/views/spree/admin/price_list_items/_form.html.erb
+++ b/backend/app/views/spree/admin/price_list_items/_form.html.erb
@@ -28,6 +28,7 @@
         <%= error_message_on :price_list, :contain_taxes %>
       <% end %>
     </div>
+    <%= f.hidden_field :is_pricelist_price, value: true %>
   </div>
 </div>
 <div class="clear"></div>

--- a/backend/app/views/spree/admin/prices/_master_variant_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_master_variant_table.html.erb
@@ -25,12 +25,16 @@
         <td><%= price.currency %></td>
         <td><%= price.money.to_html %></td>
         <td class="actions">
-          <% if can?(:edit, price) %>
+          <% if can?(:edit, price) && !price.is_pricelist_price %>
             <%= link_to_edit(price, no_text: true) unless price.discarded? %>
           <% end %>
-          <% if can?(:destroy, price) %>
+          <% if can?(:destroy, price) && !price.is_pricelist_price %>
             &nbsp;
             <%= link_to_delete(price, no_text: true) unless price.discarded? %>
+          <% end %>
+          <% if price.is_pricelist_price  %>
+            &nbsp;
+            <%= link_to price.price_list.name, edit_admin_price_list_path(price.price_list) %>
           <% end %>
         </td>
       </tr>

--- a/backend/app/views/spree/admin/prices/_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_table.html.erb
@@ -20,12 +20,16 @@
           <td><%= price.currency %></td>
           <td><%= price.money.to_html %></td>
           <td class="actions">
-            <% if can?(:edit, price) %>
+            <% if can?(:edit, price) && !price.is_pricelist_price %>
               <%= link_to_edit(price, no_text: true) unless price.discarded? %>
             <% end %>
-            <% if can?(:destroy, price) %>
+            <% if can?(:destroy, price) && !price.is_pricelist_price  %>
               &nbsp;
               <%= link_to_delete(price, no_text: true) unless price.discarded? %>
+            <% end %>
+            <% if price.is_pricelist_price  %>
+              &nbsp;
+              <%= link_to price.price_list.name, edit_admin_price_list_path(price.price_list) %>
             <% end %>
           </td>
         </tr>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -895,6 +895,8 @@ en:
         any_country: Any Country
         edit:
           edit_price: Edit Price
+        errors:
+          price_belongs_to_pricelist: Price belongs to price list and cannot be edited or deleted from product page
         index:
           amount_greater_than: Amount greater than
           amount_less_than: Amount less than

--- a/core/db/migrate/20250409101641_add_is_pricelist_price_to_prices.rb
+++ b/core/db/migrate/20250409101641_add_is_pricelist_price_to_prices.rb
@@ -1,0 +1,5 @@
+class AddIsPricelistPriceToPrices < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_prices, :is_pricelist_price, :boolean, default: false
+  end
+end


### PR DESCRIPTION
### Restrict Price Edits for Price List Prices

This pull request introduces restrictions on editing or deleting prices that are associated with a price list from product tab. It adds localization, view updates, and backend checks to prevent modifications to prices that belong to price lists, ensuring better integrity in the pricing system.

#### Key Features:
1. **Localization and View Updates for Price List Prices**:
   - Added a new localization key for an error message indicating that a price belongs to a price list and cannot be edited or deleted.
   - Updated the master variant price table and the general price table of product tab in the admin interface:
     - Prevented editing and deleting of prices that belong to a price list.
     - Displayed a message indicating the associated price lists for prices that are part of a price list.
   - Added a hidden field `is_pricelist_price` to the price list item form to track whether a price belongs to a price list.

2. **Price List Price Check for Variants and Prices**:
   - Implemented `check_pricelist_price` method in the variant API and price admin controllers to prevent users from updating prices that are associated with a price list.
   - Ensured that the system enforces the restriction on editing prices that are part of a price list at both the backend and user interface levels.

3. **New Attribute `is_pricelist_price` in Spree Price Model**:
   - Added a boolean attribute `is_pricelist_price` to the `Spree::Price` model to identify whether a price has been created for a price list.
   - This attribute helps differentiate prices that are part of price lists from regular product prices, providing additional control and flexibility in managing pricing.

#### Benefits:
- **Price Integrity**: Prevents accidental modification or deletion of prices that are part of a price list, ensuring that the pricing structure remains intact.
- **Improved User Interface**: The admin interface now provides clear feedback when attempting to edit or delete prices associated with a price list, improving user experience and reducing errors.
- **Backend Enforcement**: The addition of backend checks ensures that users cannot bypass the restrictions when interacting with the API or admin controllers.
- **Flexible Price Management**: The `is_pricelist_price` attribute allows for easier identification and management of prices that belong to price lists.
