### PR TITLE
Provide basic group functionality for customer segmentation

### DIFF
--- a/api/app/controllers/spree/api/users_controller.rb
+++ b/api/app/controllers/spree/api/users_controller.rb
@@ -31,6 +31,8 @@ class Spree::Api::UsersController < Spree::Api::BaseController
     @user = user_class.new(permitted_user_params)
 
     if @user.save
+      set_user_group if current_store&.enforce_group_upon_signup
+
       respond_with(@user, status: 201, default_template: :show)
     else
       invalid_resource!(@user)
@@ -84,6 +86,17 @@ class Spree::Api::UsersController < Spree::Api::BaseController
       super | [:email]
     else
       super
+    end
+  end
+
+  # Sets the user group for a user if they don't have one assigned
+  # This method checks if there's a user (@user) and if they don't have a user group on sign up
+  # If these conditions are met, it assigns the default cart user group from the current store
+  # If enforce_group_upon_signup is enabled on the store settings
+  def set_user_group
+    if @user && @user.user_group.nil?
+      user_group = current_store.default_cart_user_group
+      @user.update(user_group: user_group) if user_group
     end
   end
 end

--- a/api/lib/spree/api_configuration.rb
+++ b/api/lib/spree/api_configuration.rb
@@ -118,7 +118,7 @@ module Spree
       :id, :month, :year, :cc_type, :last_digits, :name
     ]
 
-    preference :user_attributes, :array, default: [:id, :email, :created_at, :updated_at, :customer_metadata]
+    preference :user_attributes, :array, default: [:id, :email, :user_group_id, :created_at, :updated_at, :customer_metadata]
 
     preference :property_attributes, :array, default: [:id, :name, :presentation]
 

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -137,7 +137,7 @@ module Spree
     # by changing a user with higher priveleges' email to one a lower-priveleged
     # admin owns. Creating a user with an email is handled separate at the
     # controller level.
-    @@user_attributes = [:password, :password_confirmation, customer_metadata: {}]
+    @@user_attributes = [:password, :password_confirmation, :user_group_id, customer_metadata: {}]
 
     @@variant_attributes = [
       :name, :presentation, :cost_price, :lock_version,


### PR DESCRIPTION

**Overview**:

This pull request introduces functionality to automatically assign a user group to new users upon signup, based on the store's configuration. This enhancement allows for better user management and organization within the application by ensuring that users are categorized into appropriate groups from the moment they register.

**Key Changes**:

1. **User  Group Assignment Logic**:
   - Implemented the `set_user_group` method in the `Spree::Api::UsersController`. This method checks if the current store has the `enforce_group_upon_signup` setting enabled and assigns the default user group to new users accordingly.

2. **API Configuration Update**:
   - Updated the `user_attributes` preference in `Spree::ApiConfiguration` to include `:user_group_id`. This change allows the user group information to be included in API responses for user details.

3. **Request Specs for User Group Assignment**:
   - Added tests to the user request specs to verify the correct assignment of the default user group upon user creation. Scenarios were included to ensure that the user group is assigned when `enforce_group_upon_signup` is enabled and not assigned when it is disabled.

4. **Permitted Attributes Update**:
   - Updated the `@@user_attributes` in `Spree::PermittedAttributes` to include `:user_group_id`, allowing the user group to be permitted during user creation and updates via the API.

**Benefits**:
- Enhances user management by ensuring new users are automatically categorized into the appropriate user group.
- Provides a more robust API response by including user group information.
